### PR TITLE
configure shared_memory

### DIFF
--- a/lora_huggingface/remote_flow.py
+++ b/lora_huggingface/remote_flow.py
@@ -47,7 +47,7 @@ class LlamaInstructionTuning(FlowSpec, HuggingFaceLora):
     @gpu_profile(interval=0.5)
     @model(load=["hf_model_checkpoint"])
     @checkpoint
-    @kubernetes(image=HF_IMAGE, gpu=N_GPU, cpu=14, memory=72000)
+    @kubernetes(image=HF_IMAGE, gpu=N_GPU, cpu=14, memory=72000, shared_memory=1000)
     @retry(times=3)
     @step
     def finetune(self):


### PR DESCRIPTION
for multi-gpu training setting shared_memory is required otherwise the training loop hangs